### PR TITLE
add wrapper function for MESSI

### DIFF
--- a/messi.py
+++ b/messi.py
@@ -1,0 +1,112 @@
+import os
+import read_data as rd
+import subprocess as sp
+from icecream import ic
+
+ISAX_BIN = os.environ.get(
+    "MESSI_ISAX_BIN", "/home/qwang/projects/isax-modularized/build/isax"
+)
+
+
+def _run_messi(
+    data,
+    queries,
+    k,
+    database_size,
+    query_size,
+    series_length,
+    sax_length,
+    sax_cardinality,
+    leaf_size,
+    cpu_cores,
+    log_filepath,
+):
+    args = [
+        ISAX_BIN,
+        "--database_filepath",
+        data,
+        "--query_filepath",
+        queries,
+        "--database_size",
+        database_size,
+        "--query_size",
+        query_size,
+        "--sax_length",
+        sax_length,
+        "--sax_cardinality",
+        sax_cardinality,
+        "--cpu_cores",
+        cpu_cores,
+        "--log_filepath",
+        log_filepath,
+        "--series_length",
+        series_length,
+        "--adhoc_breakpoints",
+        "--leaf_size",
+        leaf_size,
+        "--k",
+        k,
+        "--with_id",
+    ]
+    sp.run(list(map(str, args)))
+
+    counters = list()
+    with open(log_filepath) as fp:
+        for line in fp.readlines():
+            if "l2square" in line and "query_engine.c" in line:
+                toks = line.split()
+                counts = {
+                    "q_idx": int(toks[5]),
+                    "l2square": int(toks[7]),
+                    "sum2sax": int(toks[10]),
+                }
+                counters.append(counts)
+    return counters
+
+
+def messi_stats(data, queries, k, sax_length, sax_cardinality, leaf_size, cpu_cores):
+    """Collect statistics on a MESSI with the given parameters"""
+    database_size, series_length = rd.parse_filename(data)
+    queries_size, queries_series_length = rd.parse_filename(queries)
+    assert series_length, queries_series_length
+    log = "/tmp/messi.log"
+    if os.path.exists(log):
+        os.remove(log)
+
+    res = _run_messi(
+        data,
+        queries,
+        k,
+        database_size,
+        queries_size,
+        series_length,
+        sax_length,
+        sax_cardinality,
+        leaf_size,
+        cpu_cores,
+        log_filepath=log,
+    )
+
+    os.remove(log)
+    return res
+
+
+if __name__ == "__main__":
+    import pandas as pd
+
+    DATA = ".data/sald-128-1000000.bin"
+    QUERIES = r".data/generated/dataset~sald-128-1000000/k~10/num_queries~5/difficulty~faiss_ivf/target_lower~0.04/target_upper~0.060000000000000005/scale~10/initial_temperature~10.hdf5"
+    TMP = "/tmp/sald-128-5.bin"
+
+    rd.hdf5_to_bin(QUERIES, TMP, "test")
+
+    res = messi_stats(
+        DATA,
+        TMP,
+        k=1,
+        sax_length=16,
+        sax_cardinality=8,
+        leaf_size=10000,
+        cpu_cores=4,
+    )
+    print(pd.DataFrame(res))

--- a/read_data.py
+++ b/read_data.py
@@ -5,29 +5,29 @@ import requests
 from utils import compute_distances
 import sys
 
-DATA_DIR = os.environ.get("WORKGEN_DATA_DIR", ".data") #/mnt/hddhelp/workgen_data/
+DATA_DIR = os.environ.get("WORKGEN_DATA_DIR", ".data")  # /mnt/hddhelp/workgen_data/
 GENERATED_DIR = os.path.join(DATA_DIR, "generated")
 
-dataset_path="/data/qwang/datasets/" # TODO: simlinks in /mnt/hddhelp/workgen_data/
-sald_noise_path="/mnt/hddhelp/ts_benchmarks/datasets/sald/"
+dataset_path = "/data/qwang/datasets/"  # TODO: simlinks in /mnt/hddhelp/workgen_data/
+sald_noise_path = "/mnt/hddhelp/ts_benchmarks/datasets/sald/"
 glove_noise_path = "/mnt/hddhelp/ts_benchmarks/datasets/annbench/glove100/"
 
 DATASETS = {
-"astro": f"{dataset_path}astro-256-100m.bin",
-"deep1b": f"{dataset_path}deep1b-96-100m.bin",
-"f10": f"{dataset_path}f10-256-100m.bin",
-"f5": f"{dataset_path}f5-256-100m.bin",
-"rw": f"{dataset_path}rw-256-100m.bin",
-"seismic": f"{dataset_path}seismic-256-100m.bin",
-"sald": f"{dataset_path}sald-128-100m.bin",
-"fashion-mnist": "fashion-mnist-784-euclidean.hdf5",
-"glove-100": "glove-100-angular.hdf5",
-"glove-25": "glove-25-angular.hdf5",
-"glove-200": "glove-200-angular.hdf5",
-"mnist": "mnist-784-euclidean.hdf5",
-"sift": "sift-128-euclidean.hdf5",
-"glove-100-bin": f"{glove_noise_path}glove-100-1183514-angular.bin",
-"sald-small": f"{DATA_DIR}sald-128-1m.bin",
+    "astro": f"{dataset_path}astro-256-100m.bin",
+    "deep1b": f"{dataset_path}deep1b-96-100m.bin",
+    "f10": f"{dataset_path}f10-256-100m.bin",
+    "f5": f"{dataset_path}f5-256-100m.bin",
+    "rw": f"{dataset_path}rw-256-100m.bin",
+    "seismic": f"{dataset_path}seismic-256-100m.bin",
+    "sald": f"{dataset_path}sald-128-100m.bin",
+    "fashion-mnist": "fashion-mnist-784-euclidean.hdf5",
+    "glove-100": "glove-100-angular.hdf5",
+    "glove-25": "glove-25-angular.hdf5",
+    "glove-200": "glove-200-angular.hdf5",
+    "mnist": "mnist-784-euclidean.hdf5",
+    "sift": "sift-128-euclidean.hdf5",
+    "glove-100-bin": f"{glove_noise_path}glove-100-1183514-angular.bin",
+    "sald-small": f"{DATA_DIR}sald-128-1m.bin",
 }
 
 WORKLOADS = {
@@ -172,8 +172,8 @@ def hdf5_to_bin(input_path, output_path, what, fname_check=True, with_padding=Tr
     if with_padding:
         dim = data.shape[1]
         padsize = (8 - (dim % 8)) % 8
-        print("Padding with", padsize, "dimensions")
         if padsize > 0:
+            print("Padding with", padsize, "dimensions")
             padding = np.zeros((data.shape[0], padsize), dtype=np.float32)
             data = np.hstack([data, padding])
     if fname_check:
@@ -189,7 +189,7 @@ def hdf5_to_bin(input_path, output_path, what, fname_check=True, with_padding=Tr
     # check that the conversion produced the same files
     base, _ = read_multiformat(input_path, what)
     converted, _ = read_multiformat(output_path, what)
-    if padsize is not None:
+    if padsize is not None and padsize > 0:
         converted = converted[:, :-padsize]
     assert np.all(
         np.isclose(base, converted)


### PR DESCRIPTION
I extracted the functionality provided by the `run_messi_shell` rule in a module that takes care of extracting the dimensionality parameters from the file names. This basically implements the observation in #7 .

What would you think about integrating it in the workflow? (this would also make the snakefile a bit shorter)