### PR TITLE
address parallelization issues in metrics.get_epsilons

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,7 @@ import numpy as np
 DATASETS = {
     "fashion-mnist": ".fashion-mnist-784-euclidean.hdf5",
     "glove-100": ".glove-100-angular.hdf5",
-    "glove-25": ".glove-25-angular.hdf5"
+    "glove-25": ".glove-25-angular.hdf5",
 }
 
 
@@ -13,13 +13,13 @@ def compute_distances(queries, k, metric, data_or_index):
     Compute the k smallest distances from the given query in the
     specified metric space. The last argument can be either:
 
-      - a dataset, in which case the distance is brute forced, 
+      - a dataset, in which case the distance is brute forced,
       - or a FAISS index to be used to answer the query
 
     The function applies the appropriate adjustments so that the output is:
 
       - the Euclidean distance (not squared) is `metric="euclidean"`
-      - the angular distance (i.e. 1 - dot(q,d), with q being the query 
+      - the angular distance (i.e. 1 - dot(q,d), with q being the query
         and d a data point) if `metric="angular"`
 
     If `k` is None, then all distances are returned
@@ -30,26 +30,26 @@ def compute_distances(queries, k, metric, data_or_index):
         queries = np.array([queries])
 
     if metric == "angular":
-        assert np.all(np.isclose(1.0, np.linalg.norm(queries, axis=1))), f"queries should have unit norm, has norm {np.linalg.norm(queries, axis=1)} instead"
+        assert np.all(
+            np.isclose(1.0, np.linalg.norm(queries, axis=1))
+        ), f"queries should have unit norm, has norm {np.linalg.norm(queries, axis=1)} instead"
 
-    if hasattr(data_or_index, 'shape'):
+    if hasattr(data_or_index, "shape"):
         dataset = data_or_index
         if metric == "angular":
-            assert np.allclose(1.0, np.linalg.norm(dataset, axis=1)), "Data points should have unit norm"
-            dists = np.array([
-                1 - np.dot(dataset, query)
-                for query in queries
-            ])
+            assert np.allclose(
+                1.0, np.linalg.norm(dataset, axis=1)
+            ), "Data points should have unit norm"
+            dists = np.array([1 - np.dot(dataset, query) for query in queries])
         elif metric == "euclidean":
-            dists = np.array([
-                np.linalg.norm(query - dataset, axis=1)
-                for query in queries
-            ])
+            dists = np.array(
+                [np.linalg.norm(query - dataset, axis=1) for query in queries]
+            )
         else:
             raise RuntimeError("unknown distance" + metric)
         if k is not None:
             dists.partition(k, axis=1)
-            dists = dists[:,:k] # np.partition(dists, k)[:k]
+            dists = dists[:, :k]  # np.partition(dists, k)[:k]
         assert np.all(dists >= 0)
         return np.sort(dists)
     else:
@@ -58,10 +58,10 @@ def compute_distances(queries, k, metric, data_or_index):
             k = faiss_index.ntotal
         dists = faiss_index.search(queries, k)[0]
         if metric == "angular":
-            # The index returns squared euclidean distances, 
+            # The index returns squared euclidean distances,
             # which we turn to angular distances in the following
             return 1 - (2 - dists) / 2
-        elif metric == "euclidean" :
+        elif metric == "euclidean":
             # The index returns the _squared_ euclidean distances
             return np.sqrt(dists)
         else:
@@ -70,7 +70,7 @@ def compute_distances(queries, k, metric, data_or_index):
 
 def compute_recall(ground_distances, run_distances, count, epsilon=1e-3):
     """
-    Compute the recall against the given ground truth, for `count` 
+    Compute the recall against the given ground truth, for `count`
     number of neighbors.
     """
     t = ground_distances[count - 1] + epsilon
@@ -79,6 +79,3 @@ def compute_recall(ground_distances, run_distances, count, epsilon=1e-3):
         if d <= t:
             actual += 1
     return float(actual) / float(count)
-
-
-


### PR DESCRIPTION
As outlined in issue #11 Python has issues with multithreading on large datasets.
This commit tries to address this by delegating the parallel processing to the C++ code of FAISS. In fact, if we pass an index instead of a dataset to the function utils.compute_distances then the distance computation is delegated to the index. In particular, using a "flat" index runs all the queries in parallel.

We can then use Numpy's vectorized operations to combine all the results.

Closes #11